### PR TITLE
android: simplify generated Kotlin code

### DIFF
--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -38,7 +38,7 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
     {% if !variant.has_fields() -%}
     object {{ variant|type_name(ci) }} : {{ type_name }}()
     {% else -%}
-    data class {{ variant|type_name(ci) }}(
+    class {{ variant|type_name(ci) }}(
         {% for field in variant.fields() -%}
         {%- call kt::docstring(field, 8) %}
         val {{ field.name()|var_name }}: {{ field|type_name(ci) }}{% if loop.last %}{% else %}, {% endif %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/EnumTemplate.kt
@@ -13,7 +13,6 @@ enum class {{ type_name }} {
     {%- call kt::docstring(variant, 4) %}
     {{ variant|variant_name }}{% if loop.last %};{% else %},{% endif %}
     {%- endfor %}
-    companion object
 }
 
 public object {{ e|ffi_converter_name }}: FfiConverterRustBuffer<{{ type_name }}> {
@@ -44,9 +43,7 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
         {%- call kt::docstring(field, 8) %}
         val {{ field.name()|var_name }}: {{ field|type_name(ci) }}{% if loop.last %}{% else %}, {% endif %}
         {% endfor -%}
-    ) : {{ type_name }}() {
-        companion object
-    }
+    ) : {{ type_name }}()
     {%- endif %}
     {% endfor %}
 
@@ -66,7 +63,6 @@ sealed class {{ type_name }}{% if contains_object_references %}: Disposable {% e
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
     {% endif %}
-    companion object
 }
 
 public object {{ e|ffi_converter_name }} : FfiConverterRustBuffer<{{ type_name }}>{


### PR DESCRIPTION
1. Get rid of `companion object`: these are used only to let clients add static extensions functions. We never ever use them
2. Get rid of `data` classes for enumerations: these generate a lot of code we probably don't use as we are always mapping to our own domain objects.